### PR TITLE
Make cache-extension works with twig 2.x & 3.x but no longer 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php":       ">=5.3.2",
-        "twig/twig": "^1.0|^2.0"
+        "twig/twig": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0 || ^4.8.10",

--- a/lib/Twig/CacheExtension/Extension.php
+++ b/lib/Twig/CacheExtension/Extension.php
@@ -11,12 +11,14 @@
 
 namespace Twig\CacheExtension;
 
+use Twig\Extension\AbstractExtension;
+
 /**
  * Extension for caching template blocks with twig.
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class Extension extends \Twig_Extension
+class Extension extends AbstractExtension
 {
     private $cacheStrategy;
 
@@ -41,10 +43,7 @@ class Extension extends \Twig_Extension
      */
     public function getName()
     {
-        if (version_compare(\Twig_Environment::VERSION, '1.26.0', '>=')) {
-            return __CLASS__;
-        }
-        return 'twig_cache';
+        return __CLASS__;
     }
 
     /**

--- a/lib/Twig/CacheExtension/Node/CacheNode.php
+++ b/lib/Twig/CacheExtension/Node/CacheNode.php
@@ -11,23 +11,27 @@
 
 namespace Twig\CacheExtension\Node;
 
+use Twig\Compiler;
+use Twig\Node\Expression\AbstractExpression;
+use Twig\Node\Node;
+
 /**
  * Cache twig node.
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class CacheNode extends \Twig_Node
+class CacheNode extends Node
 {
     private static $cacheCount = 1;
 
     /**
-     * @param \Twig_Node_Expression $annotation
-     * @param \Twig_Node_Expression $keyInfo
-     * @param \Twig_NodeInterface   $body
+     * @param AbstractExpression $annotation
+     * @param AbstractExpression $keyInfo
+     * @param Node   $body
      * @param integer               $lineno
      * @param string                $tag
      */
-    public function __construct(\Twig_Node_Expression $annotation, \Twig_Node_Expression $keyInfo, \Twig_Node $body, $lineno, $tag = null)
+    public function __construct(AbstractExpression $annotation, AbstractExpression $keyInfo, Node $body, $lineno, $tag = null)
     {
         parent::__construct(array('key_info' => $keyInfo, 'body' => $body, 'annotation' => $annotation), array(), $lineno, $tag);
     }
@@ -35,15 +39,11 @@ class CacheNode extends \Twig_Node
     /**
      * {@inheritDoc}
      */
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(Compiler $compiler)
     {
         $i = self::$cacheCount++;
 
-        if (version_compare(\Twig_Environment::VERSION, '1.26.0', '>=')) {
-            $extension = 'Twig\CacheExtension\Extension';
-        } else {
-            $extension = 'twig_cache';
-        }
+        $extension = 'Twig\CacheExtension\Extension';
 
         $compiler
             ->addDebugInfo($this)

--- a/lib/Twig/CacheExtension/TokenParser/Cache.php
+++ b/lib/Twig/CacheExtension/TokenParser/Cache.php
@@ -12,20 +12,22 @@
 namespace Twig\CacheExtension\TokenParser;
 
 use Twig\CacheExtension\Node\CacheNode;
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
 
 /**
  * Parser for cache/endcache blocks.
  *
  * @author Alexander <iam.asm89@gmail.com>
  */
-class Cache extends \Twig_TokenParser
+class Cache extends AbstractTokenParser
 {
     /**
-     * @param \Twig_Token $token
+     * @param Token $token
      *
      * @return boolean
      */
-    public function decideCacheEnd(\Twig_Token $token)
+    public function decideCacheEnd(Token $token)
     {
         return $token->test('endcache');
     }
@@ -41,7 +43,7 @@ class Cache extends \Twig_TokenParser
     /**
      * {@inheritDoc}
      */
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
@@ -50,9 +52,9 @@ class Cache extends \Twig_TokenParser
 
         $key = $this->parser->getExpressionParser()->parseExpression();
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideCacheEnd'), true);
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new CacheNode($annotation, $key, $body, $lineno, $this->getTag());
     }

--- a/test/Twig/CacheExtension/Tests/FunctionalExtensionTest.php
+++ b/test/Twig/CacheExtension/Tests/FunctionalExtensionTest.php
@@ -18,8 +18,8 @@ use Twig\CacheExtension\CacheStrategy\IndexedChainingCacheStrategy;
 use Twig\CacheExtension\CacheStrategy\LifetimeCacheStrategy;
 use Twig\CacheExtension\Extension;
 use Doctrine\Common\Cache\ArrayCache;
-use Twig_Loader_Filesystem;
-use Twig_Environment;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 class FunctionalExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -58,8 +58,8 @@ class FunctionalExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function createTwig($cacheStrategyName = null)
     {
-        $loader = new Twig_Loader_Filesystem(__DIR__ . '/fixtures/');
-        $twig = new Twig_Environment($loader);
+        $loader = new FilesystemLoader(__DIR__ . '/fixtures/');
+        $twig = new Environment($loader);
 
         $cacheExtension = new Extension($this->createCacheStrategy($cacheStrategyName));
 
@@ -130,12 +130,11 @@ class FunctionalExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Hello fabpot!', $rendered3);
     }
 
-    /**
-     * @expectedException Twig_Error_Runtime
-     * @expectedExceptionMessage An exception has been thrown during the rendering of a template ("No strategy key found in value.")
-     */
     public function testIndexedChainingStrategyNeedsKey()
     {
+        $this->expectException(\Twig\Error\RuntimeError::class);
+        $this->expectExceptionMessage('An exception has been thrown during the rendering of a template ("No strategy key found in value.")');
+
         $twig = $this->createTwig('indexed');
 
         $twig->render('ics_no_key.twig', array('value' => $this->getValue('asm89', 1)));


### PR DESCRIPTION
Hi,

Quick update to make the extension available for twig 3.x.
Unfortunately it'll drop the twig 1.x support.

regards,

Bruno